### PR TITLE
Fix pnpm install frozen lockfile error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           
       - uses: actions/setup-node@v4
         with:
@@ -43,7 +43,7 @@ jobs:
       
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           
       - uses: actions/setup-node@v4
         with:

--- a/tests/variant.test.ts
+++ b/tests/variant.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getVariantContent } from '@/lib/variant'
+import { getVariantContent } from '@/lib/variant-content'
 
 describe('Variant Content', () => {
   it('should return v1 content', () => {


### PR DESCRIPTION
Update PNPM version in CI to 9 to match the lockfile version and resolve `ERR_PNPM_NO_LOCKFILE`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e611b930-6531-45e2-bcd7-36143ecff502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e611b930-6531-45e2-bcd7-36143ecff502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

