### PR TITLE
Add sole trader roles to dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ CREATE INDEX idx_leads_email ON leads(email);
 1. Create a new base in Airtable
 2. Create a table called "Leads" with these fields:
    - Email (Email field)
-   - Role (Single select: cleaner, gardener, handyman, dog_walker, other)
+   - Role (Single select: cleaner, gardener, handyman, dog_walker, plumber, electrician, painter, carpenter, locksmith, pest_control, window_cleaner, tutor, personal_trainer, massage_therapist, hairdresser, beautician, photographer, graphic_designer, web_developer, bookkeeper, virtual_assistant, other)
    - Business Type (Single select: sole_trader, micro_team)
    - Notes (Long text)
    - Source (Single line text)

--- a/components/LeadForm.tsx
+++ b/components/LeadForm.tsx
@@ -133,6 +133,23 @@ export function LeadForm({ variant, utm }: LeadFormProps) {
                 <SelectItem value="gardener">Gardener</SelectItem>
                 <SelectItem value="handyman">Handyman</SelectItem>
                 <SelectItem value="dog_walker">Dog Walker</SelectItem>
+                <SelectItem value="plumber">Plumber</SelectItem>
+                <SelectItem value="electrician">Electrician</SelectItem>
+                <SelectItem value="painter">Painter</SelectItem>
+                <SelectItem value="carpenter">Carpenter</SelectItem>
+                <SelectItem value="locksmith">Locksmith</SelectItem>
+                <SelectItem value="pest_control">Pest Control</SelectItem>
+                <SelectItem value="window_cleaner">Window Cleaner</SelectItem>
+                <SelectItem value="tutor">Tutor</SelectItem>
+                <SelectItem value="personal_trainer">Personal Trainer</SelectItem>
+                <SelectItem value="massage_therapist">Massage Therapist</SelectItem>
+                <SelectItem value="hairdresser">Hairdresser</SelectItem>
+                <SelectItem value="beautician">Beautician</SelectItem>
+                <SelectItem value="photographer">Photographer</SelectItem>
+                <SelectItem value="graphic_designer">Graphic Designer</SelectItem>
+                <SelectItem value="web_developer">Web Developer</SelectItem>
+                <SelectItem value="bookkeeper">Bookkeeper</SelectItem>
+                <SelectItem value="virtual_assistant">Virtual Assistant</SelectItem>
                 <SelectItem value="other">Other</SelectItem>
               </SelectContent>
             </Select>

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const leadSchema = z.object({
   email: z.string().email('Please enter a valid email address'),
-  role: z.enum(['cleaner', 'gardener', 'handyman', 'dog_walker', 'other'], {
+  role: z.enum(['cleaner', 'gardener', 'handyman', 'dog_walker', 'plumber', 'electrician', 'painter', 'carpenter', 'locksmith', 'pest_control', 'window_cleaner', 'tutor', 'personal_trainer', 'massage_therapist', 'hairdresser', 'beautician', 'photographer', 'graphic_designer', 'web_developer', 'bookkeeper', 'virtual_assistant', 'other'], {
     required_error: 'Please select your role',
   }),
   biz_type: z.enum(['sole_trader', 'micro_team'], {


### PR DESCRIPTION
Add 18 new roles to the lead form dropdown to support a wider range of sole trader/micro businesses.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ce3eeb8-f58a-43e5-8080-066a229fea28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ce3eeb8-f58a-43e5-8080-066a229fea28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

